### PR TITLE
fix: bug in private network guide

### DIFF
--- a/text/0033-private-network-guide.md
+++ b/text/0033-private-network-guide.md
@@ -136,7 +136,7 @@ from hathor.conf.settings import HathorSettings
 SETTINGS = HathorSettings(
     P2PKH_VERSION_BYTE=b'\x49',
     MULTISIG_VERSION_BYTE=b'\x87',
-    NETWORK_NAME='private-network',
+    NETWORK_NAME='private-testnet',
     BOOTSTRAP_DNS=[],
     # Genesis stuff
     GENESIS_OUTPUT_SCRIPT=bytes.fromhex("$GENESIS_OUTPUT_SCRIPT"),
@@ -158,7 +158,7 @@ from hathor.transaction import genesis
 
 settings = HathorSettings()
 
-# This should output 'private-network'
+# This should output 'private-testnet'
 print('NETWORK', settings.NETWORK_NAME)
 
 for tx_name in ['BLOCK_GENESIS', 'TX_GENESIS1', 'TX_GENESIS2']:


### PR DESCRIPTION
We had a small bug that prevented the wallet-headless from being started when executing the steps in the guide.

Before our improvement in the wallet-lib to accept other Networks, it is required that the name of our Network contains `testnet` in it so the wallet-headless accepts it. Otherwise we get an error.