### PR TITLE
docs(references): update references to Hathor docs website

### DIFF
--- a/projects/atomic-swap-service/headless-wallet.md
+++ b/projects/atomic-swap-service/headless-wallet.md
@@ -94,7 +94,7 @@ Calls to this route for a `proposalId` that has not been registered will raise a
 Should the backend return a `404` error, the proposal is considered obsolete and can be removed from the `listenedProposals` map.
 
 ### Update endpoint
-The [current workflow](https://hathor.gitbook.io/hathor/guides/headless-wallet/atomic-swap#step-3-bob-updates-alices-partial-transaction) of updating proposals will be kept unaltered, requiring calls to the `[POST] /wallet/atomic-swap/tx-proposal` route. However, in order to persist the changes on the Atomic Swap Service, the additional body parameter `service.proposal_id` must also be informed on the request.
+The [current workflow](https://docs.hathor.network/tutorials/headless-wallet/atomic-swaps#step-3-bob-updates-alices-partial-transaction-proposal) of updating proposals will be kept unaltered, requiring calls to the `[POST] /wallet/atomic-swap/tx-proposal` route. However, in order to persist the changes on the Atomic Swap Service, the additional body parameter `service.proposal_id` must also be informed on the request.
 
 Calling this route with a proposal identifier that has not been registered will raise a `400` error. Any errors raised while interacting with the service will also be treated and returned on the http response.
 

--- a/projects/hathor-wallet-headless/0001-multisig-create-mint-melt-token.md
+++ b/projects/hathor-wallet-headless/0001-multisig-create-mint-melt-token.md
@@ -55,7 +55,7 @@ As our intend is to execute commands, the verb `POST` is the most convenient met
 
 ## Create custom token
 
-A single wallet can [create a token](https://hathor.gitbook.io/hathor/guides/headless-wallet/creating-tokens) using `POST:/wallet/create-token` endpoint. This operation creates mint and melt authorities by default.
+A single wallet can [create a token](https://docs.hathor.network/references/headless-wallet/http-api#operation/createToken) using `POST:/wallet/create-token` endpoint. This operation creates mint and melt authorities by default.
 
 To provide a seamless extension to create a custom token in the MultiSig wallet, the endpoint keeps the same command:
 * `POST:/wallet/p2sh/tx-proposal/create-token`
@@ -73,7 +73,7 @@ The data fields are:
 * `melt_authority_address`
 * `allow_external_melt_authority_address`
 
-*`*` as required field 
+*`*` as required field
 
 The response scheme for success:
 ```ts
@@ -89,7 +89,7 @@ With this specification we cover the possibility to create custom tokens with or
 
 ## Mint a custom token
 
-A single wallet can [mint a token](https://hathor.gitbook.io/hathor/guides/headless-wallet/creating-tokens/mint-tokens) using `POST:/wallet/mint-token` endpoint. This operation creates another mint authority by default.
+A single wallet can [mint a token](https://docs.hathor.network/references/headless-wallet/http-api#operation/mintTokens) using `POST:/wallet/mint-token` endpoint. This operation creates another mint authority by default.
 
 For the MultiSig wallet the endpoint keeps the same command:
 `POST:/wallet/p2sh/tx-proposal/mint-token`
@@ -102,7 +102,7 @@ The data fields are:
 * `mint_authority_address`
 * `allow_external_mint_authority_address`
 
-*`*` as required field 
+*`*` as required field
 
 The response scheme for success:
 ```ts
@@ -131,7 +131,7 @@ The data fields are:
 * `melt_authority_address`
 * `allow_external_melt_authority_address`
 
-*`*` as required field 
+*`*` as required field
 
 The response scheme for success:
 ```ts
@@ -147,7 +147,7 @@ With this specification we cover the possibility to melt tokens, send it to anot
 
 ## Decode transaction with wallet metadata
 
-There is an endpoint to [inspect the transaction](https://hathor.gitbook.io/hathor/guides/multisig-wallet/sending-transactions#5.-check-the-multisig-transaction) by decoding the transaction hexadecimal encode in `POST:/wallet/decode`. However, it doesn't bring signature information, nor wallet information with it.
+There is an endpoint to [inspect the transaction](https://docs.hathor.network/references/headless-wallet/http-api) by decoding the transaction hexadecimal encode in `POST:/wallet/decode`. However, it doesn't bring signature information, nor wallet information with it.
 
 By extending this endpoint operation to include wallet metadata we introduce a breaking change in the API. However, we keep coherence, once it is used not only to decode a `txHex` but to decode a partial transaction. The extension adds a semantic decoding of the transaction components regarding the wallet. Also, it reduces the roundtrips to the wallet by delivering the tokens balance.
 
@@ -249,7 +249,7 @@ Despite the current design provides a minimal set of operations to enable the EV
 # Prior art
 [prior-art]: #prior-art
 
-* This design is a complement for the  [EVM compatible bridge design](https://github.com/HathorNetwork/rfcs/blob/doc/evm-compatible-brigde/projects/evm-compatible-bridge/design.md#federation-service). 
+* This design is a complement for the  [EVM compatible bridge design](https://github.com/HathorNetwork/rfcs/blob/doc/evm-compatible-brigde/projects/evm-compatible-bridge/design.md#federation-service).
 * The commands to create token, mint and melt includes a fine tuned authority creation after the PRs [#291](https://github.com/HathorNetwork/hathor-wallet-headless/pull/291) and [#293](https://github.com/HathorNetwork/hathor-wallet-headless/pull/293) in the wallet-headless.
 
 # Unresolved questions
@@ -276,7 +276,7 @@ We can specify the following data fields:
 * `token`*
 * `count`*
 
-*`*` as required field 
+*`*` as required field
 
 The response scheme for success:
 ```ts
@@ -303,7 +303,7 @@ We can specify the following data fields:
 * `authority_address`*
 * `allow_external_authority_address`
 
-*`*` as required field 
+*`*` as required field
 
 The response scheme for success:
 ```ts

--- a/projects/web-wallet/wallet-connect/0002-caip-2.md
+++ b/projects/web-wallet/wallet-connect/0002-caip-2.md
@@ -75,7 +75,7 @@ hathor:privatenet
 ## References
 * [Hathor Network](https://hathor.network/) - Hathor Website
 * [Hathor Resources](https://hathor.network/resources/) - Various useful resources for working with Hathor Network
-* [Hathor GitBook](https://hathor.gitbook.io/) - Documentation of multiple APIs that are part of the Hathor ecosystem
+* [Hathor docs](https://docs.hathor.network) - Official technical documentation of Hathor.
 
 ## Copyright
 

--- a/projects/web-wallet/wallet-connect/0003-caip-10.md
+++ b/projects/web-wallet/wallet-connect/0003-caip-10.md
@@ -51,7 +51,7 @@ hathor:testnet:WQDn4KwWrP3dacWbn35iUgea4GPFzV4s35
 ## References
 
 - [Hathor Network](https://hathor.network/)
-- [Hathor Addresses](https://hathor.gitbook.io/hathor/fundamentals/key-concepts/addresses)
+- [Hathor Addresses](https://docs.hathor.network/explanations/blockchain-foundations/addresses)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 


### PR DESCRIPTION
### Motivation

Update broken links that pointed to the old technical documentation website hosted on Gitbook.

### Acceptance Criteria

All documents that had links pointing to any page on Gitbook have been redirected to the corresponding page on the Hathor docs website.