### PR TITLE
RFC: Sub-second finality

### DIFF
--- a/text/0000-subsecond-finality-bls-benchmark.md
+++ b/text/0000-subsecond-finality-bls-benchmark.md
@@ -1,0 +1,244 @@
+# BLS12-381 (`blst`) signing & verification benchmark
+
+- Date: 2026-06-16
+- Purpose: decide the digital-signature backend for sub-second finality. The v1 implementation uses
+  `py_ecc` (pure-Python BLS) for clean packaging, but it is slow; this measures the production-grade
+  native library (`blst`) to confirm the latency/throughput headroom before committing.
+- Related: [`0000-subsecond-finality.md`](0000-subsecond-finality.md) (crypto lives in
+  `hathor/finality/crypto.py`, written behind a swappable backend wrapper).
+
+## TL;DR
+
+- `blst` single-thread: **sign ≈ 0.23 ms (~4,300/s)**, **verify ≈ 0.60 ms (~1,650/s)**, **one full
+  certificate (FastAggregateVerify) ≈ 0.55–0.64 ms** and **constant in committee size**.
+- That is **~400× faster than `py_ecc` for a single verify** and **~1,400× faster for a 100-signer
+  certificate**.
+- At these speeds the signature is **not** the bottleneck: one certificate verify (0.6 ms) is <0.5%
+  of the ~150–300 ms global soft-finality network round-trip. The earlier `py_ecc` slowness (≈16 s to
+  verify a 100-vote quorum) is what would have blown the sub-second target; `blst` removes it entirely.
+- **Decision implication:** keep BLS; the only production change that matters is swapping the backend
+  `py_ecc → blst` behind the existing wrapper. Raw speed should not drive BLS-vs-Schnorr — both are
+  orders of magnitude under the network budget — so choose on structure (non-interactive
+  observe-then-aggregate, constant-size accountable certificates, no nonce state), which favors BLS.
+
+## Environment
+
+| | |
+|---|---|
+| CPU | 13th Gen Intel(R) Core(TM) i7-13700K (8 P-cores + 8 E-cores, 24 threads) |
+| OS | Linux 6.8.0 |
+| Toolchain | rustc/cargo 1.95.0 |
+| Library | `blst` v0.3.16 (crate; bundles the blst C library with runtime CPU dispatch / asm) |
+| Build | `--release`, `opt-level = 3`, `lto = true`, `codegen-units = 1` |
+| Scheme | BLS12-381, **min-pubkey-size** layout (pubkey = 48 B in G1, signature = 96 B in G2) — same as Ethereum consensus and the Hathor finality implementation |
+| Ciphersuite / DST | `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_` (proof-of-possession variant) |
+| Safety setting | **subgroup checks ON** (`sig_groupcheck = true`, `pk_validate = true`) — the correct setting for untrusted network data |
+
+## Methodology
+
+- Each operation runs a warmup pass, then a fixed iteration count timed with `std::time::Instant`;
+  ops/s = iters / elapsed, ms/op = elapsed / iters.
+- **sign**: `SecretKey::sign(msg, dst, &[])`.
+- **verify (single)**: `Signature::verify(true, msg, dst, &[], &pk, true)` — measured both with and
+  without subgroup checks.
+- **FastAggregateVerify (one certificate)**: `N` validators sign the *same* message; their signatures
+  are aggregated into one 96-byte signature, then verified with
+  `Signature::fast_aggregate_verify(true, msg, dst, &pks)`. This is exactly the finality-certificate
+  check (same-message aggregation against the committee subset).
+- **aggregate**: `AggregateSignature::aggregate(&sigs, false)` — the collector folding votes into a cert.
+- **parallel verify**: 24 threads each looping single verifies for 3 s; throughput summed. Verification
+  is embarrassingly parallel (no shared state).
+
+The single message is a fixed 47-byte stand-in for the finality pin-message
+`sha256("hathor-fc-pin-v1" ‖ committee_hash ‖ tx_id)`; message length does not materially affect the
+cost (hash-to-curve dominates the message handling and is ~constant).
+
+## Results (`blst`)
+
+### Single-signer / single-thread
+
+| Operation | Throughput | Latency |
+|---|---|---|
+| sign (1 vote) | ~4,288 ops/s | 0.233 ms |
+| verify (single, with groupcheck) | ~1,650 ops/s | 0.60 ms |
+| verify (single, no groupcheck) | ~1,620 ops/s | 0.62 ms |
+| aggregate 100 sigs → 1 | ~12,121 ops/s | 0.082 ms |
+
+(Subgroup checks add only a small fraction over the two pairings, so with/without are within noise.)
+
+### Certificate verify — FastAggregateVerify by committee size N (single-thread)
+
+| N (signers) | certs/s | ms/cert | aggregate sig size |
+|---:|---:|---:|---:|
+| 4 | 1,774 | 0.564 | 96 B |
+| 7 | 1,864 | 0.537 | 96 B |
+| 10 | 1,853 | 0.540 | 96 B |
+| 31 | 1,720 | 0.582 | 96 B |
+| 64 | 1,747 | 0.573 | 96 B |
+| 100 | 1,671 | 0.598 | 96 B |
+| 128 | 1,558 | 0.642 | 96 B |
+
+**Key observation:** cost is essentially flat from N=4 to N=128 — the two pairings dominate; folding the
+bitmapped public keys is negligible. Certificate verify time **and** size are independent of committee
+size, so the committee can grow for decentralization at no verification cost.
+
+### Multi-threaded verification (whole machine)
+
+| Threads | Total verifies/s |
+|---:|---:|
+| 1 | ~1,650 |
+| 24 | ~16,400 |
+
+Scaling is ~10× rather than 24× because the 13700K's E-cores are much slower than its P-cores,
+hyperthreading adds little for compute-bound pairing code, and all-core load throttles clock frequency.
+A server with many uniform cores and `blst`'s randomized **batch verification**
+(`verify_multiple_aggregate_signatures`, not benchmarked here) would push this several-fold higher.
+
+## Comparison: `blst` vs the shipped `py_ecc` reference
+
+`py_ecc` numbers measured earlier on the same machine (pure-Python, single-thread):
+
+| Operation | `py_ecc` | `blst` | Speedup |
+|---|---:|---:|---:|
+| sign | 91.9 ms | 0.23 ms | ~400× |
+| verify (single) | 239.9 ms | 0.60 ms | ~400× |
+| FastAggregateVerify, N=10 | 295 ms | 0.54 ms | ~550× |
+| FastAggregateVerify, N=31 | 416 ms | 0.58 ms | ~720× |
+| FastAggregateVerify, N=100 | 802 ms | 0.60 ms | ~1,340× |
+
+## Interpretation for the decision
+
+Put the crypto next to the latency budget:
+
+- **One certificate verify** (paid by *every* full node per transaction): **0.6 ms** vs a global
+  soft-finality round-trip of **~150–300 ms** → crypto is **<0.5%** of the budget.
+- **A validator verifying a full quorum of votes** for a 100-node committee: 67 × 0.6 ms ≈ **40 ms**
+  single-threaded, or a few ms parallelized — still dwarfed by the network.
+- **Throughput**: ~16 k certificate-verifies/s on a single desktop is far above any realistic payment
+  rate; signing (~4,300/s/core) is a non-issue.
+
+With `py_ecc` the same 67 vote-verifies were ≈ **16 seconds** — which is precisely why it would have
+broken the RFC's sub-second target and why the backend swap is mandatory. `blst` clears that wall with
+large margin.
+
+**BLS vs Schnorr on speed:** a Schnorr verify (no pairing) is ~10–50× faster per op, but a Schnorr-list
+certificate needs `O(N)` verifies and is `O(N)` bytes, whereas BLS does **one** op per certificate at
+**constant** size. Both land orders of magnitude under the network latency, so **raw signature speed is
+not a differentiator**. Decide on the structural properties instead (covered in the RFC): non-interactive
+observe-then-aggregate, constant-size + accountable certificates, and no nonce state — all of which favor
+BLS.
+
+**Recommended production action:** keep BLS and swap the backend from `py_ecc` to `blst` behind the
+`hathor/finality/crypto.py` wrapper. In-process this is best done via the project's existing Rust crate
+(`htr-rs/crates/htr-lib`, already built and bound as `htr_lib`), exposing sign/verify/aggregate/
+fast-aggregate-verify with `sig_groupcheck`/`pk_validate` enabled for network-sourced data.
+
+## Caveats
+
+- Numbers are from a consumer desktop CPU (i7-13700K); production server CPUs will differ (often more
+  uniform cores, sometimes lower single-core clock).
+- Single-thread figures are the primary signal; the 24-thread number reflects this CPU's hybrid-core
+  layout and thermal throttling, not a hard ceiling.
+- Subgroup checks are enabled (correct for untrusted input). Trusted/own-data paths could disable them
+  for a small speedup, but network-sourced votes/certificates must keep them on.
+- Batch verification (`blst`'s randomized multi-aggregate verify) was not measured and would further
+  raise verify throughput when validating many votes/certificates together.
+
+## Reproducing
+
+Standalone crate used for this report.
+
+`Cargo.toml`:
+
+```toml
+[package]
+name = "bls_bench"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+blst = "0.3"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+```
+
+`src/main.rs`:
+
+```rust
+use blst::min_pk::{AggregateSignature, PublicKey, SecretKey, Signature};
+use blst::BLST_ERROR;
+use std::time::Instant;
+
+const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+fn keypair(seed: usize) -> (SecretKey, PublicKey) {
+    let mut ikm = [0u8; 32];
+    ikm[0] = seed as u8;
+    ikm[1] = (seed >> 8) as u8;
+    let sk = SecretKey::key_gen(&ikm, &[]).unwrap();
+    let pk = sk.sk_to_pk();
+    (sk, pk)
+}
+
+fn run(name: &str, iters: u32, mut f: impl FnMut()) {
+    for _ in 0..(iters / 10).max(1) { f(); } // warmup
+    let t0 = Instant::now();
+    for _ in 0..iters { f(); }
+    let dt = t0.elapsed().as_secs_f64();
+    println!("{:<42}{:>12.0} ops/s   ({:>8.3} ms/op)", name, iters as f64 / dt, dt / iters as f64 * 1000.0);
+}
+
+fn main() {
+    let msg = b"hathor-fc-pin-v1: 32-byte tx id goes here.......";
+    let (sk, pk) = keypair(1);
+    let sig = sk.sign(msg, DST, &[]);
+
+    println!("blst BLS12-381 (min-pk), single thread\n");
+    println!("=== single-signer ===");
+    run("sign (1 vote)", 20000, || { let _ = sk.sign(msg, DST, &[]); });
+    run("verify (single vote, with groupcheck)", 20000, || {
+        assert_eq!(sig.verify(true, msg, DST, &[], &pk, true), BLST_ERROR::BLST_SUCCESS);
+    });
+    run("verify (single vote, no groupcheck)", 20000, || {
+        assert_eq!(sig.verify(false, msg, DST, &[], &pk, false), BLST_ERROR::BLST_SUCCESS);
+    });
+
+    println!("\n=== FastAggregateVerify (one FC, same message), by committee size N ===");
+    println!("{:<8}{:>14}{:>14}", "N", "certs/s", "ms/cert");
+    for &n in &[4usize, 7, 10, 31, 64, 100, 128] {
+        let kps: Vec<(SecretKey, PublicKey)> = (0..n).map(|i| keypair(i + 2)).collect();
+        let pks: Vec<PublicKey> = kps.iter().map(|(_, p)| p.clone()).collect();
+        let sigs: Vec<Signature> = kps.iter().map(|(s, _)| s.sign(msg, DST, &[])).collect();
+        let sig_refs: Vec<&Signature> = sigs.iter().collect();
+        let agg = AggregateSignature::aggregate(&sig_refs, true).unwrap().to_signature();
+        let pk_refs: Vec<&PublicKey> = pks.iter().collect();
+
+        let iters = 5000u32;
+        for _ in 0..200 { let _ = agg.fast_aggregate_verify(true, msg, DST, &pk_refs); }
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            assert_eq!(agg.fast_aggregate_verify(true, msg, DST, &pk_refs), BLST_ERROR::BLST_SUCCESS);
+        }
+        let dt = t0.elapsed().as_secs_f64();
+        println!("{:<8}{:>14.0}{:>14.3}", n, iters as f64 / dt, dt / iters as f64 * 1000.0);
+    }
+
+    println!("\n=== signature aggregation throughput ===");
+    let n = 100usize;
+    let kps: Vec<(SecretKey, PublicKey)> = (0..n).map(|i| keypair(i + 500)).collect();
+    let sigs: Vec<Signature> = kps.iter().map(|(s, _)| s.sign(msg, DST, &[])).collect();
+    let sig_refs: Vec<&Signature> = sigs.iter().collect();
+    run("aggregate 100 sigs -> 1", 20000, || {
+        let _ = AggregateSignature::aggregate(&sig_refs, false).unwrap();
+    });
+}
+```
+
+Run:
+
+```sh
+cargo run --release
+```

--- a/text/0000-subsecond-finality-bls-benchmark.md
+++ b/text/0000-subsecond-finality-bls-benchmark.md
@@ -1,9 +1,10 @@
 # BLS12-381 (`blst`) signing & verification benchmark
 
 - Date: 2026-06-16
-- Purpose: decide the digital-signature backend for sub-second finality. The v1 implementation uses
-  `py_ecc` (pure-Python BLS) for clean packaging, but it is slow; this measures the production-grade
-  native library (`blst`) to confirm the latency/throughput headroom before committing.
+- Purpose: confirm the digital-signature backend for sub-second finality has the latency/throughput
+  headroom the fast path needs. Measures the native `blst` library (the backend used by the
+  implementation, via the `htr_lib` Rust extension) and quantifies how far a pure-Python BLS reference
+  (`py_ecc`) falls short.
 - Related: [`0000-subsecond-finality.md`](0000-subsecond-finality.md) (crypto lives in
   `hathor/finality/crypto.py`, written behind a swappable backend wrapper).
 
@@ -16,8 +17,7 @@
 - At these speeds the signature is **not** the bottleneck: one certificate verify (0.6 ms) is <0.5%
   of the ~150–300 ms global soft-finality network round-trip. The earlier `py_ecc` slowness (≈16 s to
   verify a 100-vote quorum) is what would have blown the sub-second target; `blst` removes it entirely.
-- **Decision implication:** keep BLS; the only production change that matters is swapping the backend
-  `py_ecc → blst` behind the existing wrapper. Raw speed should not drive BLS-vs-Schnorr — both are
+- **Decision:** keep BLS, backed by native `blst`. Raw speed should not drive BLS-vs-Schnorr — both are
   orders of magnitude under the network budget — so choose on structure (non-interactive
   observe-then-aggregate, constant-size accountable certificates, no nonce state), which favors BLS.
 
@@ -94,7 +94,7 @@ hyperthreading adds little for compute-bound pairing code, and all-core load thr
 A server with many uniform cores and `blst`'s randomized **batch verification**
 (`verify_multiple_aggregate_signatures`, not benchmarked here) would push this several-fold higher.
 
-## Comparison: `blst` vs the shipped `py_ecc` reference
+## Comparison: `blst` vs a pure-Python `py_ecc` reference
 
 `py_ecc` numbers measured earlier on the same machine (pure-Python, single-thread):
 
@@ -118,7 +118,7 @@ Put the crypto next to the latency budget:
   rate; signing (~4,300/s/core) is a non-issue.
 
 With `py_ecc` the same 67 vote-verifies were ≈ **16 seconds** — which is precisely why it would have
-broken the RFC's sub-second target and why the backend swap is mandatory. `blst` clears that wall with
+broken the RFC's sub-second target and why the fast path is backed by `blst`. `blst` clears that wall with
 large margin.
 
 **BLS vs Schnorr on speed:** a Schnorr verify (no pairing) is ~10–50× faster per op, but a Schnorr-list
@@ -128,10 +128,10 @@ not a differentiator**. Decide on the structural properties instead (covered in 
 observe-then-aggregate, constant-size + accountable certificates, and no nonce state — all of which favor
 BLS.
 
-**Recommended production action:** keep BLS and swap the backend from `py_ecc` to `blst` behind the
-`hathor/finality/crypto.py` wrapper. In-process this is best done via the project's existing Rust crate
-(`htr-rs/crates/htr-lib`, already built and bound as `htr_lib`), exposing sign/verify/aggregate/
-fast-aggregate-verify with `sig_groupcheck`/`pk_validate` enabled for network-sourced data.
+**Backend:** BLS on native `blst`, behind the `hathor/finality/crypto.py` wrapper. In-process this runs
+via the project's Rust crate (`htr-rs/crates/htr-lib`, built and bound as `htr_lib`), exposing
+sign/verify/aggregate/fast-aggregate-verify with `sig_groupcheck`/`pk_validate` enabled for
+network-sourced data.
 
 ## Caveats
 

--- a/text/0000-subsecond-finality-latency-benchmark.md
+++ b/text/0000-subsecond-finality-latency-benchmark.md
@@ -1,0 +1,148 @@
+# End-to-end finality latency benchmark (collect `2f+1` → admit to mempool)
+
+- Date: 2026-06-16
+- Purpose: measure the time for a finality-eligible transaction to **collect a quorum (weight `≥ 2f+1`)
+  of validator votes and be admitted to the mempool as certified** — the soft-finality latency the RFC
+  targets at sub-second — as a function of two parameters: the **number of validators** `N` and the
+  one-way **network latency between validators** `L`.
+- Related: [`0000-subsecond-finality.md`](0000-subsecond-finality.md) and the primitive-level
+  [`0000-subsecond-finality-bls-benchmark.md`](0000-subsecond-finality-bls-benchmark.md). This benchmark
+  composes those raw BLS costs with the actual gossip protocol; read the BLS benchmark first for the
+  crypto-backend context.
+- Harness: `hathor_tests/finality/test_finality_latency_benchmark.py` (driving the real
+  `hathor/finality/service.py` fast path over a simulated network).
+- Backend: the native **`blst`** backend, reached through the `htr_lib` Rust extension
+  (`hathor/finality/crypto.py`). The comparison section also reports the same benchmark on a pure-Python
+  `py_ecc` reference, to show how far that backend falls short of the sub-second target.
+
+## TL;DR
+
+- The benchmark runs the whole validator fast path — pin, sign, flood the vote, accumulate votes,
+  assemble the `FinalityCertificate`, verify it, admit the tx — through the **real `FinalityService`**,
+  over a **discrete-event simulated network** whose per-hop latency is a parameter and whose handler CPU
+  is the **real measured `blst` cost**.
+- With `blst`, node-local certification is **≈ 3–5 ms and essentially flat from `N = 4` to `N = 100`**:
+  the crypto is off the critical path. A quorum verify (`FastAggregateVerify`) is constant in committee
+  size, so larger committees cost nothing extra.
+- Total soft finality is therefore **≈ 2·L + ~5 ms** — the two flood hops (tx out, vote back) plus a few
+  ms of crypto. Even a **100-validator committee on 100 ms links reaches soft finality in ~205 ms**,
+  comfortably sub-second with large margin.
+- A pure-Python `py_ecc` reference imposes a ~1 s node-local crypto floor *before a single network packet*
+  (see comparison) — which is exactly why the fast path uses the native `blst` backend.
+
+## Environment
+
+| | |
+|---|---|
+| CPU | 13th Gen Intel(R) Core(TM) i7-13700K (8 P-cores + 8 E-cores, 24 threads) |
+| OS | Linux 6.8.0 |
+| BLS backend | `blst` (native BLS12-381, `G2ProofOfPossession`, min-pubkey-size) via the `htr_lib` Rust extension, single-thread per handler |
+| Committee weights | uniform (weight 1 each), so `N = total weight = 3f + 1` and `quorum = 2f + 1` |
+
+## Methodology
+
+The harness wires one real `FinalityService` per validator (the same object the node runs) onto an
+in-process **discrete-event simulator** with a virtual clock:
+
+- The submission is delivered to validator 0 at virtual time `t = 0`.
+- Each message a handler sends (`flood_to_validators`, `flood_vote`, `broadcast_certificate`) is
+  buffered and, once the handler returns, scheduled for delivery to each recipient at
+  `virtual_now + handler_cpu + L` — i.e. "process the message, then it costs one network hop `L` to
+  reach the peer".
+- `handler_cpu` is the **real wall-clock `perf_counter` time** of that handler — which for these
+  handlers is almost entirely the `blst` sign/verify work (plus the small PyO3 boundary cost). So the
+  simulation combines *measured* crypto cost with the *configured* network latency.
+- **Soft finality** is recorded the first time any validator's `admit_certified_tx` fires — the instant
+  some node first sees weight `≥ 2f+1` and promotes the transaction to its mempool. That virtual
+  timestamp is the reported latency.
+
+This isolates the protocol's own latency (crypto on the critical path + network hops to a quorum); it
+does not model bandwidth, queueing under load, packet loss, or validator-CPU contention from concurrent
+transactions. Votes are sent all-to-all (every validator floods to every other), so a quorum is
+collected in ~2 hops regardless of `N`.
+
+For each `(N, L)` cell the transaction and committee (including the one-time proof-of-possession
+verification at committee load) are built **outside** the timing; only the certify round is measured,
+on a fresh pin store / pending pool / certificate store. Reported numbers are the best and median of 2
+timed iterations.
+
+## Results (`blst`)
+
+`finality(best)` / `finality(med)` = virtual time from submission to first mempool admission.
+
+| N | f | quorum | L = 0 ms | L = 25 ms | L = 100 ms |
+|---:|---:|---:|---:|---:|---:|
+| 4 | 1 | 3 | 3.9 ms | 53.4 ms | 203.0 ms |
+| 7 | 2 | 5 | 3.6 ms | 53.2 ms | 203.0 ms |
+| 10 | 3 | 7 | 3.1 ms | 53.1 ms | 203.2 ms |
+| 13 | 4 | 9 | 3.1 ms | 53.2 ms | 203.1 ms |
+| 31 | 10 | 21 | 3.7 ms | 53.7 ms | 203.6 ms |
+| 64 | 21 | 43 | 5.2 ms | 54.4 ms | 204.4 ms |
+| 100 | 33 | 67 | 5.3 ms | 55.3 ms | 205.4 ms |
+
+(Values are the best of 2 iterations; median was within ~1 ms in every cell.)
+
+**Reading the two axes:**
+
+- **Latency `L` → `≈ 2·L`, flat in `N`.** Across every committee size, the network term is the two
+  flood hops (tx out, vote back): +~50 ms at `L = 25`, +~200 ms at `L = 100`, independent of the
+  committee. Flooding collects a quorum in a constant number of hops.
+- **Committee size `N` → no meaningful growth.** The node-local floor (`L = 0`) stays ~3–5 ms from
+  `N = 4` (quorum 3) all the way to `N = 100` (quorum 67). `FastAggregateVerify` is constant in `N`, and
+  per-vote verification is ~1 ms, so the critical path barely moves — the committee can grow for
+  decentralization at no latency cost.
+- **Crypto is off the critical path.** Soft finality is now `2·L + ~5 ms`; the network round-trip
+  dominates, exactly the regime the design wants. Sub-second holds with huge margin for any realistic
+  inter-validator latency.
+
+## Comparison: native `blst` vs a pure-Python `py_ecc` reference
+
+The same benchmark on a pure-Python `py_ecc` backend (same machine, same harness), showing the
+node-local crypto floor a native backend avoids:
+
+| N | quorum | `py_ecc` L = 0 | `blst` L = 0 | speedup | `py_ecc` L = 100 | `blst` L = 100 |
+|---:|---:|---:|---:|---:|---:|---:|
+| 4 | 3 | 982 ms | 3.9 ms | ~250× | 1183 ms | 203 ms |
+| 7 | 5 | 1001 ms | 3.6 ms | ~280× | 1205 ms | 203 ms |
+| 10 | 7 | 1027 ms | 3.1 ms | ~330× | 1222 ms | 203 ms |
+| 13 | 9 | 1043 ms | 3.1 ms | ~340× | 1242 ms | 203 ms |
+
+With `py_ecc`, node-local certification alone was **≈ 1 s for the smallest committee before a single
+network packet** — the whole sub-second budget spent on pure-Python pairings — and it grew with the
+committee. A 100-validator committee would have spent ~16 s just verifying a 67-vote quorum (see
+[`0000-subsecond-finality-bls-benchmark.md`](0000-subsecond-finality-bls-benchmark.md)). `blst` keeps that
+floor at a few milliseconds and flat across committee size, leaving the `~2·L` network round-trip as the
+only material cost.
+
+## Caveats
+
+- Same consumer desktop CPU as the BLS benchmark (i7-13700K); production server CPUs differ.
+- The simulated network is uniform, lossless and uncongested, with a single in-flight transaction. It
+  captures critical-path crypto + hop count, not bandwidth, queueing, contention, or stragglers under
+  real load.
+- `handler_cpu` is real `perf_counter` time and so carries normal measurement noise; the soft-finality
+  timestamp is the *first* admission across the committee.
+- The `blst` handler cost includes the PyO3 call boundary (bytes marshalling + per-call key/signature
+  parsing with subgroup checks), so a single verify here (~1 ms) is somewhat above the pure-Rust
+  `blst` figure in [`0000-subsecond-finality-bls-benchmark.md`](0000-subsecond-finality-bls-benchmark.md)
+  (~0.6 ms). It is still ~250× under `py_ecc` and far below the network term.
+
+## Reproducing
+
+The benchmark lives in the test tree but is gated behind an environment variable so it never runs in the
+normal suite. Small committees are fast; large committees are dominated by the all-to-all vote
+verification (`O(N²)` total `blst` verifies — e.g. the `N = 100` rows take tens of seconds of wall
+clock to *run*, even though the *measured* soft-finality time is ~5 ms).
+
+```sh
+HATHOR_FINALITY_BENCH=1 \
+HATHOR_FINALITY_BENCH_SIZES=4,7,10,13,31,64,100 \
+HATHOR_FINALITY_BENCH_LATENCY_MS=0,25,100 \
+HATHOR_FINALITY_BENCH_ITERS=2 \
+  uv run pytest -p no:warnings -s hathor_tests/finality/test_finality_latency_benchmark.py
+```
+
+Parameters (all optional, comma-separated to sweep): `HATHOR_FINALITY_BENCH_SIZES` (number of
+validators `N`), `HATHOR_FINALITY_BENCH_LATENCY_MS` (one-way inter-validator latency `L`),
+`HATHOR_FINALITY_BENCH_ITERS` (timed iterations per cell). Set `HATHOR_FINALITY_BENCH_OUT=<path>` to
+also write the results table to a file.

--- a/text/0000-subsecond-finality.md
+++ b/text/0000-subsecond-finality.md
@@ -241,13 +241,20 @@ transaction before signing, so the pinned set is fully re-derivable from the tra
 certificate verification. The committee hash binds a signature to a specific committee, and the domain tag
 (`PIN_MESSAGE_TAG`) prevents cross-protocol replay.
 
-The backend (`py_ecc`, pure-Python) is wrapped behind module-level functions
-(`bls_keygen / sk_to_pk / pop_prove / pop_verify / sign / verify / aggregate / fast_aggregate_verify`) so
-it can be swapped for a native library without touching the rest of the codebase. A benchmark
-([`0000-subsecond-finality-bls-benchmark.md`](0000-subsecond-finality-bls-benchmark.md)) measured native
-`blst` at ≈ 0.6 ms per certificate verify versus ≈ 240 ms for
-`py_ecc` — a ~400× speedup, and < 0.5% of the ~150–300 ms network round-trip — making the `py_ecc → blst`
-swap the recommended (mandatory for production) backend change while leaving the protocol untouched.
+The backend is the native **`blst`** library, reached through the project's Rust extension (`htr_lib`)
+and wrapped behind module-level functions
+(`bls_keygen / sk_to_pk / pop_prove / pop_verify / sign / verify / aggregate / fast_aggregate_verify`),
+so it stays swappable without touching the rest of the codebase. Ordinary signatures and
+proofs-of-possession use **distinct domain-separation tags** (`BLS_SIG_..._POP_` vs `BLS_POP_..._POP_`),
+so a PoP can never be replayed as an ordinary vote. Because keys and signatures are parsed from untrusted
+network data, verification keeps subgroup checks (`sig_groupcheck` / `pk_validate`) **on** and treats every
+malformed input as a verification failure rather than an error.
+
+Native crypto is what makes the fast path viable: a benchmark
+([`0000-subsecond-finality-bls-benchmark.md`](0000-subsecond-finality-bls-benchmark.md)) measured `blst` at
+≈ 0.6 ms per certificate verify — < 0.5% of the ~150–300 ms network round-trip and **constant in committee
+size**. A pure-Python BLS reference (`py_ecc`) was ~400× slower (≈ 240 ms per verify, ≈ 16 s to verify a
+100-vote quorum), which would have blown the sub-second target on its own.
 
 `FinalityValidatorSigner` holds a runtime private key and exposes `sign_pin`; `FinalityValidatorSignerFile`
 is the pydantic key-file (hex private key, public key, PoP) that validates internal consistency on load.
@@ -422,8 +429,9 @@ a UTXO (a liveness failure, recoverable by the PoW tier), but they can never rev
 - **Operational complexity and layer coupling.** Block validity now depends on FCs, coupling two
   previously independent layers. Validator-set governance, key rotation, and FC dissemination are new
   responsibilities.
-- **A pure-Python BLS backend is far too slow for production.** `py_ecc` verify is ≈ 240 ms; the protocol
-  is correct with it, but production requires the `blst` backend swap.
+- **A native crypto dependency.** Sub-second verification relies on the native `blst` backend (via the
+  `htr_lib` Rust extension) — a pure-Python BLS would be ~400× too slow (≈ 240 ms per verify). This is a
+  compiled dependency in the hot path, though one already carried by the project's Rust crate.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -529,8 +537,9 @@ economics, and confidential-transaction interaction.
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-- **`blst` backend swap.** Already validated by benchmark; the recommended production change, behind the
-  existing `crypto.py` wrapper.
+- **Batch / parallel certificate verification.** `blst`'s randomized multi-aggregate verification was not
+  yet adopted; it would further raise verify throughput when a node validates many votes or certificates
+  at once. Verification is embarrassingly parallel (no shared state), so it also scales across cores.
 - **Binding FC-root block header (deferred PR G).** A 32-byte merkle root of the certified transactions in
   a block, committed in the header. v1 derives its binding security entirely from the consensus
   ratification rule (which needs the FC known only locally); a *binding* root would enable light-client

--- a/text/0000-subsecond-finality.md
+++ b/text/0000-subsecond-finality.md
@@ -414,6 +414,27 @@ validator that signs both leaves two contradictory signatures over the same UTXO
 evidence of equivocation (the basis for future slashing). Validators can withhold signatures and **stall**
 a UTXO (a liveness failure, recoverable by the PoW tier), but they can never reverse or forge.
 
+## Latency
+
+An end-to-end benchmark
+([`0000-subsecond-finality-latency-benchmark.md`](0000-subsecond-finality-latency-benchmark.md)) drives
+the real `FinalityService` fast path — pin, sign, flood the vote, accumulate, assemble the certificate,
+verify, admit — over a discrete-event simulated network whose per-hop latency `L` is a parameter and whose
+handler CPU is the *measured* `blst` cost. Two findings shape the design:
+
+- **Soft finality ≈ `2·L + ~5 ms`.** A quorum is collected in two flood hops (the transaction out to the
+  committee, the votes back), plus a few milliseconds of crypto on the critical path. The network
+  round-trip dominates; sub-second holds with large margin for any realistic inter-validator latency
+  (a 100-validator committee on 100 ms links reaches soft finality in ~205 ms).
+- **Flat in committee size.** The node-local floor stays ≈ 3–5 ms from `N = 4` to `N = 100`, because
+  `FastAggregateVerify` is constant in `N` and per-vote verification is ~1 ms. The committee can grow for
+  decentralization at essentially no latency cost — but note vote gossip is all-to-all, so a validator's
+  *work per transaction* still grows with `N` (`O(N)` vote verifies), even though the *latency* to first
+  certification does not.
+
+This is the measured basis for the "sub-second" claim, and it is why the design tolerates a sizable
+committee: the latency budget is spent almost entirely on the network, not on validators or crypto.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 
@@ -432,6 +453,10 @@ a UTXO (a liveness failure, recoverable by the PoW tier), but they can never rev
 - **A native crypto dependency.** Sub-second verification relies on the native `blst` backend (via the
   `htr_lib` Rust extension) — a pure-Python BLS would be ~400× too slow (≈ 240 ms per verify). This is a
   compiled dependency in the hot path, though one already carried by the project's Rust crate.
+- **Per-validator work grows with committee size.** Vote gossip is all-to-all, so each validator performs
+  `O(N)` vote verifications per transaction and the committee does `O(N²)` total. Soft-finality *latency*
+  stays flat in `N` (see *Latency*), but validator CPU and bandwidth do not, which bounds how large the
+  committee can grow before vote dissemination needs a smarter (e.g. aggregation-tree) overlay.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/0000-subsecond-finality.md
+++ b/text/0000-subsecond-finality.md
@@ -1,0 +1,548 @@
+- Feature Name: subsecond_finality
+- Start Date: 2026-06-16
+- RFC PR: (leave this empty)
+- Hathor Issue: (leave this empty)
+- Author: Marcelo Salhab Brogliato <msbrogli@hathor.network>
+
+# Summary
+[summary]: #summary
+
+This RFC specifies **sub-second finality** for Hathor: a fast *soft-finality* tier, produced by a fixed
+committee of **finality validators**, layered on top of the existing merged-mined Proof-of-Work
+*hard-finality* tier. Each validator, the first time it sees a transaction spending a given UTXO,
+**pins** that UTXO to the transaction and co-signs it with a BLS signature — and will never sign a
+conflicting spender. When validators of total weight `≥ 2f+1` (out of a committee calibrated as
+`W = 3f+1`) have signed, their votes aggregate into a single, constant-size **Finality Certificate
+(FC)**. A transaction is *softly final* the moment an FC exists for it — typically well under a second —
+and *hard final* the moment a PoW block settles it. The two tiers are bound by one consensus rule: **a
+PoW block is invalid if it confirms a transaction that conflicts with an already-certified one**, so PoW
+*ratifies* the fast path and can never silently reverse a soft-final payment. This document describes the
+v1 implementation as built in `hathor/finality/`: the UTXO fast path on a fixed PoA-style committee, with
+a *certified-only mempool* and *validator-driven* certificate collection.
+
+# Motivation
+[motivation]: #motivation
+
+Hathor settles transactions through merged-mined PoW blocks, which gives it Bitcoin-grade objective
+security but inherits PoW's probabilistic, multi-second confirmation latency. For the payment use cases
+Hathor is pursuing (point-of-sale, stablecoin rails), that latency is the single most visible gap against
+card networks and modern payment-oriented chains that advertise sub-second confirmation.
+
+Simply making blocks faster trades away security (shorter blocks mean lower per-block work and more
+reorgs) and does not change the fact that PoW finality is *probabilistic*. The design space payment chains
+have converged on instead keeps a slow, objective base layer and adds a **fast validator layer on top**
+that provides an immediate, cryptographically verifiable confirmation (Dash InstantSend, Sui owned
+objects, the Thunderella line of work).
+
+The expected outcome:
+
+- **Sub-second soft finality** for ordinary UTXO payments — enough for a merchant to release goods,
+  comparable to a card authorization.
+- **Unchanged hard finality**: the same merged-mined PoW settlement Hathor has today, now *ratifying* the
+  fast path rather than competing with it.
+- **No new trusted operator that can steal or forge state.** The validators can, at worst, *stall* (a
+  liveness failure); they can never reverse a settled payment or mint value. A safety violation requires a
+  collusion that is, by construction, evidenced by two contradictory signatures over the same UTXO.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## New concepts
+
+- **Finality validator.** A node in a fixed, network-configured committee that co-signs UTXO transactions.
+  Each validator has a **voting weight**. The committee and the weights live in the network settings
+  (`FINALITY` in `hathor/conf/settings.py`), PoA-style, and are gated behind the `TWO_TIER_FINALITY`
+  feature-activation bit, so every node knows who the validators are and when the subsystem turns on.
+- **The pin.** The first time a validator sees a transaction spending a UTXO, it records `(tx_id, index)
+  → spender_tx_id` in its **pin store** and signs the transaction. The pin is *immutable*: the validator
+  will never sign a different transaction spending that UTXO. This is the only rule a validator must
+  follow for safety.
+- **Vote.** A single validator's BLS signature over a transaction's canonical *pin-message*
+  (`Vote` in `hathor/finality/fc.py`).
+- **Finality Certificate (FC).** An aggregate of a quorum of votes: one 96-byte BLS signature plus a
+  committee bitmap, proving validators of weight `≥ 2f+1` pinned the transaction
+  (`FinalityCertificate` in `hathor/finality/fc.py`). It verifies against the committee with a single
+  `FastAggregateVerify` pairing check.
+- **Soft finality.** A transaction is *softly final* once an FC exists for it. This holds under the
+  assumption that the validator quorum is honest.
+- **Hard finality.** A transaction is *hard final* once a merged-mined PoW block settles it — the
+  objective, Bitcoin-grade tier Hathor has today.
+- **Ratification rule.** A PoW block is **invalid** (and gets voided) if it confirms a transaction that
+  conflicts with a transaction that already holds an FC. PoW therefore *ratifies* the fast path and can
+  never silently reverse it.
+
+## What is eligible
+
+The fast path serves **single-owner UTXO transactions**: a non-nano `Transaction` with at least one input
+(`FinalityService.is_eligible`). Blocks, genesis, and Nano Contract transactions (which touch shared
+mutable state and need a total order) do not take this path; they follow the existing flow unchanged.
+
+## How a payment flows
+
+Take Alice paying Bob:
+
+1. **Submit.** Alice's node creates `T` and, because the feature is active and `T` is eligible, the node
+   does *not* place `T` in the mempool. It keeps `T` in an in-memory **pending pool** and forwards it to a
+   committee validator. Pending transactions are never relayed to the general network by non-validators.
+2. **Collect.** Validators gossip `T` among themselves. Each honest validator checks `T`, pins every one
+   of its inputs, signs the pin-message, floods its `VOTE`, and accumulates incoming votes. The first
+   validator to accumulate weight `≥ 2f+1` assembles the FC.
+3. **Release.** That validator broadcasts the *certified transaction + FC* to the entire network. Every
+   node independently re-verifies the FC reaches quorum, stores it, admits `T` to its mempool, and relays
+   it onward. Bob's node sees the FC — the payment is **softly final**, about a quarter to half a second
+   after Alice tapped.
+4. **Settle.** A PoW block later confirms `T`; it is now **hard final**. Nothing Bob can observe changes,
+   but the payment is now objectively irreversible.
+
+The crucial discipline for receivers: **"final" means "the FC exists," not "a validator told me it was
+ok."** A single validator's acknowledgement is not finality; only the quorum certificate is.
+
+## Why a quorum is safe: every two certificates share an honest validator
+
+The whole design rests on a single counting fact. The committee has total weight `W = 3f + 1` and
+tolerates at most `f` weight of **rogue** (Byzantine, equivocating) validators. A quorum is any set of
+weight `≥ 2f + 1`. Take any two quorums `Q1` and `Q2`. Their combined weight is at least
+`(2f + 1) + (2f + 1) = 4f + 2`, but the whole committee is only `3f + 1`, so by inclusion–exclusion they
+must **overlap in weight at least `(4f + 2) − (3f + 1) = f + 1`**. Since at most `f` weight is rogue, that
+shared overlap of weight `f + 1` always contains **at least one honest validator**.
+
+That honest validator is the linchpin. It pins each UTXO immutably and signs at most one spender of it.
+So it can belong to a quorum for `T1` *or* a quorum for `T2`, never both. Therefore **two conflicting
+transactions can never both reach a quorum** — at most one finality certificate can ever exist for a given
+UTXO.
+
+A concrete committee makes this tangible. Take `f = 1`: `W = 3f + 1 = 4` validators (`v1..v4`, weight 1
+each), quorum `2f + 1 = 3`, tolerating one rogue validator. Any two 3-of-4 quorums overlap in at least
+`f + 1 = 2` validators; with at most one rogue, at least one of those two is honest. The examples below all
+use this committee.
+
+## Example (i): no conflict
+
+Alice creates `T` spending UTXO `x` to Bob and submits it. Every honest validator sees `x` unspent and
+unpinned, so each pins `x → T` and signs. `T` collects all 4 votes — well past the quorum of 3 — and an FC
+is assembled and broadcast. Bob's node verifies the FC and the payment is softly final in a fraction of a
+second. This is the overwhelmingly common case: an honest, non-conflicting payment is certified by the full
+committee almost immediately.
+
+## Example (ii): a conflict that resolves
+
+Alice tries to double-spend `x`: she sends `T1` (paying Bob) to validators `v1, v2, v3` and `T2` (paying
+Carol) to `v4`, and the race plays out so that `v1, v2, v3` each pin `x → T1` and sign `T1`, while `v4`
+pins `x → T2` and signs `T2`.
+
+- `T1` gathers votes from `v1, v2, v3` — weight 3, a quorum. Its FC is assembled and broadcast. **Bob is
+  paid; `T1` is softly final.**
+- `T2` now has only `v4` (weight 1). For `T2` to also reach quorum it would need 3 signers, but `v1, v2, v3`
+  have each *immutably* pinned `x → T1` and will never sign `T2`. The only validators left for `T2` are
+  rogue ones, and there is at most `f = 1` of those. **`T2` can never reach quorum**, so no second FC is
+  possible. Carol's node never sees an FC for `T2`, so it never treats the payment as final.
+
+The quorum-intersection fact is exactly what forbids the second certificate: any quorum for `T2` would have
+to share an honest validator with `T1`'s quorum, and that validator already pinned `x → T1`.
+
+## Example (iii): a conflict that gets stuck
+
+Alice splits the committee evenly: `T1` (to Bob) reaches `v1, v2`, and `T2` (to Carol) reaches `v3, v4`.
+Each honest validator pins whichever it saw first, so `T1` collects weight 2 and `T2` collects weight 2 —
+**neither reaches the quorum of 3.** No FC forms for either, and the UTXO `x` is now **stuck (wedged)**:
+it produces no soft finality at all until a PoW block eventually settles one of the spenders.
+
+This harms only Alice. Bob and Carol were never at risk, because each waits for an FC and neither ever
+formed. Honest users never equivocate, so an honest user's UTXO never gets stuck — the wedged case is
+exclusively self-inflicted by an equivocator.
+
+### Resolving a stuck UTXO is an open question
+
+What v1 does today is the conservative thing: a wedged UTXO simply stays frozen on the fast tier, and the
+slow tier resolves it — a PoW block eventually confirms exactly one of the conflicting spenders (Hathor's
+existing consensus already picks a single winner among conflicts), at which point the validators release
+their now-moot pins. That is always safe, but the UTXO loses its sub-second finality until a block arrives.
+
+How to recover *soft* finality for a stuck UTXO faster is **not settled in this design**. The common
+approaches, each with trade-offs, are:
+
+- **PoW tie-break.** Let the eventual block's choice be the canonical resolution and reset the pins to it.
+  Simple and already implied by the slow tier, but it offers no *fast* recovery — it is just the frozen
+  case named.
+- **Epoch-boundary unlock / forgiveness** (as in Sui Lutris): at committee rotation, forgive equivocated
+  pins so the UTXO can be re-attempted in the next epoch. Recovers liveness without weakening safety, at
+  the cost of an epoch's delay and a rotation mechanism Hathor does not yet have.
+- **Timeouts / refundable locks**, especially for multi-owner spends, so a co-signer cannot wedge a joint
+  transaction indefinitely.
+
+These are recorded as future work (see *Unresolved questions* and *Future possibilities*); v1 deliberately
+ships only the always-safe "stays frozen until PoW" behaviour.
+
+## Two layers of security, one of them battle-tested
+
+It is worth being explicit about what the validator committee is and is not trusted for. There are **two
+independent layers** guarding against a double-spend:
+
+1. **The fast (finality) layer** — the validators, pins, and BLS certificates described above. Its safety
+   rests on the honest-quorum assumption *and* on this code being correct.
+2. **The base consensus layer** — Hathor's existing merged-mined PoW consensus, which already guarantees
+   that among any set of conflicting transactions **at most one is ever confirmed** in the best chain. This
+   layer is years old and battle-tested, and it is completely independent of the finality code.
+
+The key consequence: **even if the finality implementation had a bug** that somehow produced two
+certificates for conflicting spenders of the same UTXO, the base consensus layer would *still* confirm only
+one of them — the other would be voided as a conflict, exactly as it is today without finality. A finality
+bug can therefore, at worst, **break the soft-finality promise** (a payment believed final is reversed, or
+a UTXO is wedged); it can **never cause an actual double-spend to settle on-chain**, because the ledger of
+record is the PoW chain, not the certificate.
+
+The ratification rule (a block may not confirm a transaction conflicting with a certified one) tightens
+this further by forcing PoW to confirm the *certified* winner rather than an arbitrary one — but the raw
+no-double-spend guarantee does not depend on the finality layer being correct at all. The fast tier buys
+speed; the consensus tier remains the ground truth for safety.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The implementation lives in the `hathor/finality/` package. Network and storage effects are reached
+through an injected `FinalityTransport` and callbacks, so the protocol logic in `FinalityService` is
+independent of the p2p and storage machinery and is unit-testable in isolation.
+
+```
+ any node (submitter)        committee overlay (validators gossip among themselves)        whole network
+ --------------------        -----------------------------------------------------         -------------
+ pending pool
+   └─ forward to a  ──────▶  v_i: validate + PIN every input + sign ──flood tx + VOTE──▶ v_j, v_k …
+      validator              each validator accumulates votes in its pending pool
+   (await certified result)  first to reach weight ≥ 2f+1 → assemble FC
+                             broadcast certified tx + FC ─────────────────────────────▶ every node:
+                                                                                        verify FC quorum,
+                                                                                        store FC, admit to
+                                                                                        mempool, relay,
+                                                                                        ratify in consensus
+```
+
+## Cryptography (`crypto.py`)
+
+Validators co-sign with **BLS12-381** signatures (G2 proof-of-possession ciphersuite,
+min-pubkey-size layout: public key = 48 bytes in G1, signature = 96 bytes in G2). Because every validator
+signs the *same* per-transaction message, votes aggregate with same-message aggregation and an FC verifies
+with `FastAggregateVerify` — one multi-pairing check whose cost and output size are **constant in committee
+size**.
+
+Same-message aggregate verification is only safe against rogue-key attacks when every committee public key
+carries a verified **proof-of-possession (PoP)**; the PoP is checked when the committee is loaded
+(`FinalitySettings._validate_and_derive`) and when a signer key file is loaded
+(`FinalityValidatorSignerFile`).
+
+The canonical message a validator signs is:
+
+```
+get_pin_message(tx_id, committee_hash) = sha256( b"hathor-fc-pin-v1" || committee_hash || tx_id )
+```
+
+It commits to `tx_id` **only**. This is sound because an honest validator pins *every* input of the
+transaction before signing, so the pinned set is fully re-derivable from the transaction itself during
+certificate verification. The committee hash binds a signature to a specific committee, and the domain tag
+(`PIN_MESSAGE_TAG`) prevents cross-protocol replay.
+
+The backend (`py_ecc`, pure-Python) is wrapped behind module-level functions
+(`bls_keygen / sk_to_pk / pop_prove / pop_verify / sign / verify / aggregate / fast_aggregate_verify`) so
+it can be swapped for a native library without touching the rest of the codebase. A benchmark
+([`0000-subsecond-finality-bls-benchmark.md`](0000-subsecond-finality-bls-benchmark.md)) measured native
+`blst` at ≈ 0.6 ms per certificate verify versus ≈ 240 ms for
+`py_ecc` — a ~400× speedup, and < 0.5% of the ~150–300 ms network round-trip — making the `py_ecc → blst`
+swap the recommended (mandatory for production) backend change while leaving the protocol untouched.
+
+`FinalityValidatorSigner` holds a runtime private key and exposes `sign_pin`; `FinalityValidatorSignerFile`
+is the pydantic key-file (hex private key, public key, PoP) that validates internal consistency on load.
+Both mirror the existing `PoaSigner` / `PoaSignerFile`.
+
+## Committee configuration (`finality_settings.py`)
+
+`FinalitySettings(enabled, validators[])` carries the committee. Each `FinalityValidatorSettings` is a
+`(public_key, pop, weight)` triple. On load, when enabled, it:
+
+- rejects an empty committee and duplicate public keys,
+- verifies each PoP,
+- derives total weight `W`, calibrates `f = (W - 1) // 3` (the largest `f` with `3f + 1 ≤ W`), and sets
+  `quorum_threshold = 2f + 1`.
+
+Quorum is **weight-based, not count-based**: `reaches_quorum(bitmap)` sums the weights of the validators
+selected by a committee bitmap and compares to `2f + 1`. `calculate_committee_hash()` is a stable SHA-256
+over the validators' JSON, used both to bind votes (in the pin-message) and to gate peer connections.
+
+These settings are wired into `HathorSettings` as `FINALITY`, alongside the hard flag
+`ENABLE_TWO_TIER_FINALITY`, the `CAPABILITY_FINALITY` p2p capability string, and the
+`Feature.TWO_TIER_FINALITY` activation bit (`Features.two_tier_finality`).
+
+## Wire objects (`fc.py`)
+
+- **`Vote(tx_id, validator_id, signature)`** — `tx_id(32) || validator_id(2) || signature(96)` = 130
+  bytes. The `validator_id` is a non-unique 2-byte skip-hint (first bytes of the hashed public key,
+  mirroring `PoaSignerId`); it is only used to find a candidate public key quickly and is **never** trusted
+  for membership — the signature is always verified against the committee's actual keys.
+- **`FinalityCertificate(tx_id, bitmap, agg_signature)`** —
+  `tx_id(32) || bitmap_len(1) || bitmap(bitmap_len) || agg_signature(96)`. The bitmap is a big-endian
+  integer; bit `i` set means the validator at committee index `i` is in the quorum.
+  `verify(settings)` returns true iff `reaches_quorum(bitmap)` **and** the aggregate signature verifies via
+  `bls_fast_aggregate_verify` over the recomputed pin-message. Both objects fit comfortably in a single
+  p2p line (limit 65536 bytes).
+
+## Persistent stores (`stores.py`)
+
+Two stores are **authoritative**, not derived from the DAG, and therefore cannot be rebuilt by scanning
+it. They are deliberately kept out of `IndexesManager.iter_all_indexes()` so a reindex or
+`--reset-indexes` can never wipe them, and they are exposed as `indexes.finality_pin` /
+`indexes.finality_certificate`:
+
+- **Pin store** (`FinalityPinStore`): `(tx_id, index) → pinned spender tx_id`. Its `try_pin` pins a UTXO
+  to a spender iff it is unpinned or already pinned to the same spender, and returns `False` on a conflict
+  (the caller would be equivocating and must not sign). Pins are immutable. `unpin_resolved` releases pins
+  after settlement (housekeeping only). **Losing this store would let a validator sign a second,
+  conflicting spender after a restart — the single highest-severity failure**, which is why it is never
+  rebuildable/clearable.
+- **Certificate store** (`FinalityCertificateStore`): `tx_id → FC bytes` for every FC a node has verified
+  and accepted. The ratification rule consults it with O(1) `has_certificate` lookups.
+
+Each has a RocksDB implementation (own column family) and an in-memory implementation for tests.
+
+## Pending pool (`pending_pool.py`)
+
+`PendingFinalityPool` holds finality-eligible transactions that do not yet have a quorum FC, keyed by
+`tx_id`, each with the votes accumulated so far (by committee index). It is **in-memory**: its contents are
+pre-final and can always be re-collected, so they need not survive a restart. `add_vote` is idempotent per
+validator index (anti-double-count). `is_ready` / `assemble_certificate` aggregate the accumulated votes
+(in committee-index order, so the bitmap and the aggregate agree) once they reach quorum.
+
+## The service (`service.py`)
+
+`FinalityService` orchestrates the fast path on every node. A node is a **validator** iff it was
+constructed with both a signer and a pin store (the constructor asserts they are provided together). The
+key entry points:
+
+- **`should_divert_to_pending(vertex)`** — the mempool gate predicate: true for a finality-eligible
+  transaction, while the feature is active, that does not yet have a known certificate.
+- **`submit_local_transaction(tx)`** — for a locally-created transaction: keep it pending and either vote
+  on it directly (if this node is a validator) or `submit_to_validator`.
+- **`on_submit_finality_tx(tx, source)`** — a pending tx received from a peer. A non-validator just
+  forwards it to a validator; a validator handles it.
+- **`_handle_as_validator`** — floods the tx to other validators (if newly seen), then applies the voting
+  rule and, if it passes, ingests its own vote.
+- **`_try_vote(tx)`** — the **voting rule**. Returns `None` (no vote) if the tx already has a certificate,
+  is double-spending, or spends a voided tx; if a dependency is not yet known (`TransactionDoesNotExist`),
+  it **defers** (the parent's certificate may still arrive). Otherwise it first checks no input is already
+  pinned to a *different* transaction, then **atomically pins every input** to this transaction (aborting
+  without signing on any conflict), and finally signs the pin-message and returns a `Vote`.
+- **`on_vote` / `_ingest_vote`** — verify a vote (resolving its signer by trying each committee key whose
+  2-byte hint matches and checking the BLS signature), record it, re-flood it, and — if it completes a
+  quorum — `_certify`.
+- **`on_certificate` / `_accept_certificate`** — **independent admission**: every node re-runs
+  `certificate.verify(settings)` before storing the FC, removing the tx from the pending pool, admitting it
+  to the mempool (via the injected `admit_certified_tx` callback), and re-broadcasting. A node never trusts
+  an upstream peer's certificate.
+- **`on_settlement`** — housekeeping: once a transaction is hard-settled by a block (`first_block` set and
+  not voided), release the validator's pins for its inputs. Safety does not depend on this (a consumed
+  UTXO can never be re-spent); it frees pin storage and is the hook for future wedge recovery.
+
+## p2p transport (`transport.py`, `messages.py`, `states/ready.py`)
+
+`P2PFinalityTransport` implements the `FinalityTransport` protocol over existing peer connections. The
+"committee overlay" is, in v1, simply the set of connected peers advertising `CAPABILITY_FINALITY`. Vote
+authenticity rests on BLS verification against the committee — **not** on peer identity — so a
+non-validator peer can neither forge a vote nor reach a quorum. Three new messages (gated by the shared
+capability) are added in `ProtocolMessages` and handled in `ReadyState`:
+
+- `SUBMIT_FINALITY_TX` — any node → a validator: the full pending transaction (hex). `submit_to_validator`
+  picks the first available finality peer deterministically; validator gossip fans it out.
+- `FINALITY_VOTE` — validator ↔ validator flood: a `Vote`.
+- `FINALITY_CERTIFICATE` — broadcast to all peers: a JSON `{tx, fc}` payload carrying the certified
+  transaction and its certificate (the FC travels *alongside* the tx because it signs over `tx_id` and
+  cannot live inside the tx hash).
+
+Handlers deserialize defensively, closing the connection on malformed input. Because mismatched committees
+must never exchange finality data, `FINALITY` is mixed into the peer-hello settings hash
+(`get_settings_hello_dict`) when enabled, mirroring `PoaSettings`.
+
+## Certified-only mempool gate (`vertex_handler.py`)
+
+The `VertexHandler` is the single funnel that guarantees the mempool only ever holds FC-backed finality
+transactions. In both `on_new_mempool_transaction` and `on_new_relayed_vertex`, `_divert_to_finality`
+checks `should_divert_to_pending`; if true, it hands the tx to `on_submit_finality_tx` (which keeps it
+pending and gets it certified) and **returns without admitting or relaying it**. A certified transaction
+arriving via `FINALITY_CERTIFICATE` re-enters through `admit_certified_tx` after independent verification.
+The service is set after construction (`set_finality_service`) to avoid a circular dependency, and is
+`None` when the feature is disabled.
+
+## Ratification rule (`block_consensus.py`)
+
+The binding rule lives in consensus, not the verifier, because the confirmed-transaction set only exists at
+consensus time. In `BlockConsensusAlgorithm._score_block_dfs`, just before a block becomes best chain (and
+sets `meta.first_block`), the algorithm calls:
+
+- **`_fc_enabled_for(block)`** — gates on the block parent's `Features` (mirroring `_should_execute_nano`),
+  false for genesis.
+- **`_confirms_certified_conflict(block)`** — for each transaction the block confirms, and each input, it
+  scans the conflicting siblings (`spent_meta.spent_outputs[index]`); if any sibling `t' != tx` holds a
+  certificate (`fc_index.has_certificate`), the block is confirming a transaction conflicting with a
+  certified one.
+
+When that holds, the block is **voided** by reusing the existing non-winner voiding path (`must_void`) —
+it becomes a voided side block while the certified tx and its descendants stay valid. This composes with
+reorg handling for free and never crashes the node. The rule gates on **FC existence**, not on
+`first_block`, because a certified transaction need not yet be block-confirmed.
+
+## Wiring
+
+`--finality-signer-file` (in `run_node_args.py`) supplies a validator's key. Both `Builder` and
+`CliBuilder` construct the `FinalityService` (with the pending pool, certificate store, transport, and
+admit callback) on every node when the feature is enabled, and additionally load the signer and pin store
+on validator nodes. Settlement pin-release is driven by a pubsub adapter (`handle_consensus_event` →
+`on_settlement`).
+
+## Safety argument
+
+The safety property — **two conflicting transactions can never both obtain an FC** — follows from quorum
+intersection plus immutable pins. Any FC needs validators of weight `≥ 2f+1`. Two FCs over conflicting
+spenders of the same UTXO would need two such quorums; in a committee of total weight `W = 3f + 1`, any two
+weight-`(2f+1)` sets intersect in weight `≥ f + 1`, i.e. at least one honest validator (weight `> f` of
+honest weight). But an honest validator pins each UTXO immutably and signs at most one spender, so it
+cannot be in both quorums. Therefore at most one conflicting spender is ever certified. A dishonest
+validator that signs both leaves two contradictory signatures over the same UTXO — objective, attributable
+evidence of equivocation (the basis for future slashing). Validators can withhold signatures and **stall**
+a UTXO (a liveness failure, recoverable by the PoW tier), but they can never reverse or forge.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- **Soft finality is a weaker guarantee than PoW.** It rests on the honesty of a `2f+1` validator quorum.
+  Although accountable, it is weaker than objective hashpower, and receivers who treat soft finality as
+  equivalent to settlement take on that assumption. Clear UX is required.
+- **Validators are a new locus of centralisation and censorship.** A committee can delay (censor)
+  transactions even though it cannot reverse them. The escape valve is the PoW tier, but censorship
+  resistance is weaker than a pure-PoW mempool.
+- **New liveness corner cases.** Wedged UTXOs, partitions, and multi-owner griefing are new failure modes.
+  They are safe (self-harm only) but add complexity, and in v1 a wedged UTXO simply stays frozen until PoW
+  resolves it.
+- **Operational complexity and layer coupling.** Block validity now depends on FCs, coupling two
+  previously independent layers. Validator-set governance, key rotation, and FC dissemination are new
+  responsibilities.
+- **A pure-Python BLS backend is far too slow for production.** `py_ecc` verify is ≈ 240 ms; the protocol
+  is correct with it, but production requires the `blst` backend swap.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+The core choice is *how the fast tier resolves conflicts*:
+
+1. **Single leader / sequencer per epoch** (Solana, rollups). One party orders everything so conflicts
+   cannot arise — but it is a single point of liveness and censorship, and leader failover needs BFT
+   anyway. Rejected: it reintroduces exactly the privileged operator Hathor's value proposition argues
+   against.
+2. **Consensusless quorum certificates** (this RFC; FastPay / Sui owned objects / Dash InstantSend).
+   Leaderless, one round-trip, no total order, and a structural fit for single-owner UTXOs. Its only
+   weakness — wedged UTXOs — is covered by the PoW tier Hathor already has. **Adopted.**
+3. **Full total-order BFT for everything** (Tendermint, HotStuff). Strong but pays consensus latency for
+   *every* payment, including the vast majority that never conflict. Rejected for the UTXO path; reserved
+   for the Nano-Contract path, where shared state genuinely needs a total order.
+
+The **certificate-as-block-validity-rule** is the load-bearing decision that makes the two tiers coherent:
+it turns "PoW could in principle reorg the fast path" into "PoW provably ratifies it." Without it, soft and
+hard finality could disagree and the soft tier would be merely advisory.
+
+Implementation-level choices and the rationale for each:
+
+- **BLS over Schnorr.** Both are orders of magnitude under the network latency budget, so raw speed is not
+  the differentiator. BLS is chosen for *structure*: non-interactive observe-then-aggregate, constant-size
+  and accountable certificates, and no nonce state — all of which fit a leaderless committee. (Benchmarks:
+  [`0000-subsecond-finality-bls-benchmark.md`](0000-subsecond-finality-bls-benchmark.md).)
+- **Weight-based `3f+1` calibration** rather than node counts, so the committee can use stake- or
+  trust-weighted voting without changing the quorum math.
+- **`tx_id`-only pin-message** (rather than committing to the input set in the signature), sound because
+  honest validators pin every input before signing — keeping votes and certificates compact and
+  re-derivable.
+- **Certified-only mempool + validator-driven collection.** This deviates from the original RFC's
+  client-driven framing (where validators never message one another). Making the mempool certified-only
+  gives a single, uniform admission funnel on every node, and validator gossip keeps the committee
+  well-connected without depending on a client to chase signatures.
+- **Authoritative, non-rebuildable pin/certificate stores** kept out of the reindex loop, because an
+  accidental wipe of the pin store is the highest-severity failure (it would permit equivocation).
+- **Voiding the offending block** rather than crashing, so the ratification rule composes with the existing
+  reorg machinery.
+
+**Impact of not doing this:** Hathor keeps multi-second, probabilistic confirmation and remains
+uncompetitive for point-of-sale and real-time payment rails — the exact market currently in focus.
+
+# Prior art
+[prior-art]: #prior-art
+
+No system combines all three of this design's defining choices (consensusless per-UTXO certificate +
+merged-mined-Bitcoin PoW hard tier + cert-as-block-validity-rule), but each tier has strong precedent:
+
+- **FastPay** (Baudet, Danezis, Sonnino, AFT 2020, arXiv:2003.11506) — the direct ancestor: Byzantine
+  consistent broadcast on `(account, sequence-number)`, `2f+1`/`3f+1` quorum, self-harm-only conflicts.
+  Our per-UTXO pin is the UTXO analogue of its per-`(account, seq)` pin. Single-tier (no PoW).
+- **Sui Lutris / Mysticeti** (arXiv:2310.18042, 2310.14821) — productionises the idea on an object model:
+  owned objects take a consensusless certificate path, shared objects fall back to DAG-BFT, ~390 ms on
+  mainnet. Owned objects ≈ our pinned UTXOs. Sui forgives equivocated objects at epoch boundaries — a
+  cleaner stuck-object recovery than relying only on the slow tier (see Future possibilities).
+- **Dash InstantSend + ChainLocks** — mechanically our Tier 1, in production since 2019: LLMQ masternodes
+  threshold-sign each transaction input and skip conflicting inputs (DIP-0010/0006) — exactly our per-UTXO
+  pin — aggregating into a single BLS `isdlock`. Key divergence: Dash's anti-reorg tier is another
+  masternode quorum (ChainLocks), not objective merged-mined PoW, and the lock is not a block-validity
+  rule.
+- **Thunderella** (Pass & Shi, EuroCrypt 2018) — the academic template for an optimistic fast committee
+  over a slow PoW fallback that ratifies and never loses safety. It is leader-driven and needs `>¾`
+  honest; we chose leaderless, `>⅔`, and accountable.
+- **Babylon** (arXiv:2408.01896) — fast BFT finality providers over Bitcoin with EOTS-based slashing;
+  closest to our "fast accountable layer over a Bitcoin-grade base" thesis, but total-order BFT anchored
+  via checkpoints rather than merged-mining with a cert-as-block-rule.
+- **Casper FFG / Gasper (Ethereum)** and **GRANDPA (Polkadot)** — supply the `⅓`-accountable-safety math
+  we reuse (two conflicting finalized decisions ⇒ `≥⅓` weight provably culpable), instantiated here
+  *per UTXO*.
+- **Syscoin Z-DAG** — our exact base (merged-mined Bitcoin + UTXO + ~60 s settlement) but a *probabilistic*
+  fast tier with no certificate; it demonstrates the base we want paired with the fast tier we reject. The
+  FastPay-style certificate is precisely what closes that gap.
+
+**Lesson summary.** The fast tier is not speculative — Dash and Sui run it in production at ~0.4–1 s, and
+the accountable-safety math is standard. Hathor's contribution is binding a *consensusless* fast
+certificate to *merged-mined Bitcoin PoW* via a block-validity rule, so objective hashpower ratifies every
+instant payment.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+To resolve through the RFC process / before stabilisation:
+
+- **PoA vs PoS for the committee, and who slashes.** v1 ships a fixed, network-configured PoA committee.
+  Moving to staking and economic slashing — turning equivocation evidence into a punishable offense — is
+  deferred and determines whether soft finality is economically or only reputationally accountable.
+- **Committee membership proof at handshake.** v1's overlay is "peers advertising `CAPABILITY_FINALITY`";
+  safety does not depend on it (BLS verification is the real gate), but a handshake proof of committee
+  membership would harden against DoS and improve privacy.
+- **Stuck-UTXO recovery policy.** v1 leaves a wedged UTXO frozen until PoW settlement. A PoW tie-break
+  ordering rule and/or Sui-style epoch-boundary unlock are open.
+- **Multi-owner griefing.** A mechanism to stop a co-signer from wedging a joint transaction (input-level
+  timeouts, refundable locks, or routing multi-owner spends to the total-order path).
+- **Late-FC reconciliation edge cases.** The certified-only mempool covers the common case (a node holding
+  a certified tx already has its FC). The residual case — a block references a certified tx the node has
+  not seen — needs an explicit fetch path.
+
+Out of scope for this RFC: the Nano-Contract total-order BFT design, validator fee/incentive and anti-spam
+economics, and confidential-transaction interaction.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+- **`blst` backend swap.** Already validated by benchmark; the recommended production change, behind the
+  existing `crypto.py` wrapper.
+- **Binding FC-root block header (deferred PR G).** A 32-byte merkle root of the certified transactions in
+  a block, committed in the header. v1 derives its binding security entirely from the consensus
+  ratification rule (which needs the FC known only locally); a *binding* root would enable light-client
+  header-only verification of soft finality — attractive for mobile wallets and external verifiers.
+- **PoS staking and economic slashing.** Turn the two-contradictory-signatures equivocation evidence into
+  on-chain fraud proofs and stake slashing.
+- **Epoch governance, rotation, and epoch-boundary unlock** (from Sui Lutris) — forgive and unlock
+  equivocated UTXOs at committee rotation, improving liveness without weakening safety.
+- **ChainLocks-style fallback hard tier** (from Dash) — a validator-quorum anti-reorg backstop, useful
+  transitionally if merged-mining hashrate on the fast tier is ever thin.
+- **Nano-Contract total-order path.** The BFT counterpart for shared-state transactions, sharing the
+  committee and the ratification rule with this fast path.
+- **Confidential and cross-chain settlement.** The pin is over UTXO identity, not value, so the fast path
+  is compatible in principle with Pedersen-committed confidential outputs; and the two tiers map naturally
+  onto cross-chain transfers (softly final on certification, hard final on mainnet settlement).


### PR DESCRIPTION
- Feature Name: subsecond_finality
- Start Date: 2026-06-16
- RFC PR: HathorNetwork/rfcs#117
- Hathor Issue: (leave this empty)
- Author: Marcelo Salhab Brogliato <msbrogli@hathor.network>

# Summary

A fast *soft-finality* tier produced by a fixed committee of **finality validators**, layered on Hathor's existing merged-mined PoW *hard-finality* tier. Each validator **pins** and BLS-co-signs the first spender it sees of a UTXO and never signs a conflict; a weighted quorum (`2f+1` of `3f+1`) aggregates into a constant-size **Finality Certificate**. One consensus rule binds the tiers: a PoW block is invalid if it confirms a transaction conflicting with an already-certified one, so PoW *ratifies* the fast path and can never silently reverse a soft-final payment. Written from the v1 implementation in `hathor/finality/`.

# Motivation

PoW settlement is objective but probabilistic and multi-second — the most visible gap against card networks and payment-oriented chains for the point-of-sale / stablecoin use cases Hathor targets. This adds a sub-second, cryptographically verifiable confirmation on top of unchanged PoW, with no new operator that can steal or forge state (validators can at worst stall).

# Guide-level explanation

Introduces finality validators, the pin, votes, the Finality Certificate, soft vs. hard finality, and the ratification rule. Includes the quorum-intersection safety argument (any two `2f+1` quorums in a `3f+1` committee share ≥ `f+1` validators, hence ≥ 1 honest), worked examples (no conflict / conflict that resolves / conflict that gets stuck), the open question of stuck-UTXO recovery, and the two-layer security model (fast tier + the battle-tested PoW consensus that alone guarantees no on-chain double-spend even if the fast tier has a bug).

# Reference-level explanation

Covers the `hathor/finality/` package: BLS crypto on the native `blst` backend; weight-based `W=3f+1` / quorum `2f+1` committee config; `Vote` / `FinalityCertificate` wire formats; authoritative (non-rebuildable) pin and certificate stores; the in-memory pending pool; the `FinalityService` voting/certification/admission logic; p2p transport and capability; the certified-only mempool gate; and the consensus ratification rule that voids an offending block. Includes the quorum-intersection safety argument and a measured **latency** section (soft finality ≈ `2·L + ~5 ms`, flat in committee size — e.g. a 100-validator committee on 100 ms links reaches soft finality in ~205 ms).

# Drawbacks

Soft finality is weaker than PoW (honest-quorum assumption); validators are a new centralisation/censorship locus; new liveness corner cases (wedged UTXOs, partitions, multi-owner griefing); operational complexity and layer coupling; a native crypto dependency in the hot path; per-validator vote-verification work grows `O(N)` with committee size (all-to-all gossip), even though latency stays flat.

# Rationale and alternatives

Consensusless quorum certificates (chosen) vs. a single leader/sequencer (reintroduces a privileged operator) vs. full total-order BFT for everything (pays consensus latency for payments that never conflict; reserved for the Nano-Contract path). The certificate-as-block-validity-rule is the load-bearing choice that makes the two tiers coherent. Plus implementation-level rationale (BLS vs. Schnorr, weight-based calibration, `tx_id`-only pin-message, certified-only mempool, voiding vs. crashing).

# Prior art

FastPay, Sui Lutris/Mysticeti, Dash InstantSend+ChainLocks, Thunderella, Babylon, Casper FFG/Gasper & GRANDPA, Syscoin Z-DAG. The contribution is binding a *consensusless* fast certificate to *merged-mined Bitcoin PoW* via a block-validity rule.

# Unresolved questions

PoA vs. PoS and who slashes; handshake committee-membership proof; stuck-UTXO recovery policy; multi-owner griefing; late-FC reconciliation edge cases. Out of scope: Nano-Contract BFT design, validator economics, confidential-transaction interaction.

# Future possibilities

Batch/parallel certificate verification; binding FC-root block header for light clients; PoS staking + economic slashing; epoch governance/rotation + epoch-boundary unlock; ChainLocks-style fallback hard tier; the Nano-Contract total-order path; confidential and cross-chain settlement.

---

### Files in this PR

- `text/0000-subsecond-finality.md` — the design RFC.
- `text/0000-subsecond-finality-bls-benchmark.md` — companion BLS signing/verification benchmark (`blst`).
- `text/0000-subsecond-finality-latency-benchmark.md` — companion end-to-end soft-finality latency benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)